### PR TITLE
fix: WORDS game mode, 50 WORDS and above ends correctly.

### DIFF
--- a/tttui/__init__.py
+++ b/tttui/__init__.py
@@ -96,6 +96,8 @@ def main(stdscr):
                 stdscr.nodelay(False)
                 continue
 
+            game.update_current_line(test_state)
+
             ui.display_test_ui(stdscr, test_state)
             key_code = stdscr.getch()
             if key_code == -1:

--- a/tttui/game.py
+++ b/tttui/game.py
@@ -80,3 +80,16 @@ def calculate_results(state, personal_best):
         "char_stats": char_stats,
         "is_new_pb": is_new_pb,
     }
+
+def update_current_line(test_state):
+    curr_len = len(test_state["current_text"])
+    lines = test_state["lines"]
+    cumulative_len = 0
+
+    for idx,line in enumerate(lines):
+        cumulative_len += len(line) + 1
+        if curr_len < cumulative_len:
+            test_state["current_line_idx"] = idx
+            return
+
+    test_state["current_line_idx"] = len(lines) - 1

--- a/tttui/storage.py
+++ b/tttui/storage.py
@@ -68,7 +68,7 @@ def load_items(item_type, language):
     dir_path = config.LANGUAGES_DIR if item_type == "words" else config.QUOTES_DIR
     file_path = os.path.join(dir_path, f"{language}.txt")
     try:
-        with open(file_path, "r", encoding="utf-8") as f:
+        with open(file_path, "r", encoding="utf-8-sig") as f:
             items = [line.strip() for line in f if line.strip()]
         return items if items else [f"No {item_type} found for {language}"]
     except FileNotFoundError:


### PR DESCRIPTION
There was an issue with the scrolling of the screen especially once it goes beyond line 2 ``[0,1,2]``, i.e 50 WORDS and above. 

So, despite completely typing out all the words from 0-2, you would think that all 50 words are done, but below that there are still words that haven't been typed, thus resulting in the `` is_over `` still being false. 

This solves the issue and updates the line after finishing a line.