### PR TITLE
feat: delete words with ctrl+backspace while typing

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ menu = ["tab m"]
 history = ["g"]
 cancel = ["esc"]
 backspace = ["backspace"]
+delete_word = ["ctrl+backspace", "ctrl+h", "ctrl+w", "alt+backspace"]
 ```
 
 Keybindings support multi-key sequences such as `"tab enter"` and modified keys such as `"ctrl+r"`.

--- a/crates/tttui_app/src/app.rs
+++ b/crates/tttui_app/src/app.rs
@@ -2,10 +2,14 @@ use std::collections::BTreeMap;
 use std::io;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
-use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyEventKind};
+use crossterm::event::{
+    self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers, KeyboardEnhancementFlags,
+    PopKeyboardEnhancementFlags, PushKeyboardEnhancementFlags,
+};
 use crossterm::execute;
 use crossterm::terminal::{
-    disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen,
+    disable_raw_mode, enable_raw_mode, supports_keyboard_enhancement, EnterAlternateScreen,
+    LeaveAlternateScreen,
 };
 use ratatui::backend::CrosstermBackend;
 use ratatui::layout::{Alignment, Constraint, Direction, Layout, Rect};
@@ -42,9 +46,19 @@ pub fn run() -> AppResult<()> {
     enable_raw_mode()?;
     let mut stdout = io::stdout();
     execute!(stdout, EnterAlternateScreen)?;
+    let keyboard_enhanced = supports_keyboard_enhancement().unwrap_or(false);
+    if keyboard_enhanced {
+        execute!(
+            stdout,
+            PushKeyboardEnhancementFlags(KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES)
+        )?;
+    }
     let backend = CrosstermBackend::new(stdout);
     let mut terminal = Terminal::new(backend)?;
     let result = app.run(&mut terminal, &preferences);
+    if keyboard_enhanced {
+        execute!(terminal.backend_mut(), PopKeyboardEnhancementFlags)?;
+    }
     disable_raw_mode()?;
     execute!(terminal.backend_mut(), LeaveAlternateScreen)?;
     terminal.show_cursor()?;
@@ -244,7 +258,7 @@ where
     fn handle_test_key(&mut self, key: KeyEvent) -> AppResult<bool> {
         if let Some(action) =
             self.matcher
-                .push_for_actions(&key, &self.keymap, &["restart", "menu"])
+                .push_for_actions(&key, &self.keymap, &["restart", "menu", "delete_word"])
         {
             match action.as_str() {
                 "restart" => {
@@ -255,6 +269,12 @@ where
                     self.screen = Screen::Home;
                     return Ok(true);
                 }
+                "delete_word" => {
+                    if let Screen::Test(session) = &mut self.screen {
+                        session.delete_word();
+                    }
+                    return Ok(true);
+                }
                 _ => {}
             }
         }
@@ -262,7 +282,11 @@ where
         if let Screen::Test(session) = &mut self.screen {
             match key.code {
                 KeyCode::Backspace => session.backspace(),
-                KeyCode::Char(value) => {
+                KeyCode::Char(value)
+                    if !key
+                        .modifiers
+                        .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT) =>
+                {
                     session.start_if_needed(Instant::now());
                     session.push_char(value);
                 }

--- a/crates/tttui_app/src/config/app_config.rs
+++ b/crates/tttui_app/src/config/app_config.rs
@@ -40,6 +40,15 @@ impl Default for AppConfig {
         keybindings.insert("history".into(), vec!["g".into()]);
         keybindings.insert("cancel".into(), vec!["esc".into()]);
         keybindings.insert("backspace".into(), vec!["backspace".into()]);
+        keybindings.insert(
+            "delete_word".into(),
+            vec![
+                "ctrl+backspace".into(),
+                "ctrl+h".into(),
+                "ctrl+w".into(),
+                "alt+backspace".into(),
+            ],
+        );
 
         Self {
             defaults: Defaults::default(),

--- a/crates/tttui_app/src/features/typing_test/domain/session.rs
+++ b/crates/tttui_app/src/features/typing_test/domain/session.rs
@@ -52,6 +52,17 @@ impl TestSession {
         self.input.pop();
     }
 
+    pub fn delete_word(&mut self) {
+        let mut new_len = self.input.len();
+        while new_len > 0 && self.target.get(new_len - 1) == Some(&' ') {
+            new_len -= 1;
+        }
+        while new_len > 0 && self.target.get(new_len - 1).is_some_and(|c| *c != ' ') {
+            new_len -= 1;
+        }
+        self.input.truncate(new_len);
+    }
+
     pub fn typed_chars(&self) -> usize {
         self.input.len()
     }
@@ -162,6 +173,45 @@ fn consistency(history: &[(Duration, f64)], net_wpm: f64) -> f64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn delete_word_is_noop_on_empty_input() {
+        let mut session = TestSession::new(TestMode::Words(2), "english".into(), "cat dog".into());
+        session.delete_word();
+        assert!(session.input.is_empty());
+    }
+
+    #[test]
+    fn delete_word_removes_partial_word() {
+        let mut session = TestSession::new(TestMode::Words(2), "english".into(), "cat dog".into());
+        session.input = vec!['c', 'a', 't', ' ', 'd', 'o'];
+        session.delete_word();
+        assert_eq!(session.input, vec!['c', 'a', 't', ' ']);
+    }
+
+    #[test]
+    fn delete_word_at_word_start_removes_previous_word() {
+        let mut session = TestSession::new(TestMode::Words(2), "english".into(), "cat dog".into());
+        session.input = vec!['c', 'a', 't', ' '];
+        session.delete_word();
+        assert!(session.input.is_empty());
+    }
+
+    #[test]
+    fn delete_word_uses_target_boundaries_for_mistyped_space() {
+        let mut session = TestSession::new(TestMode::Words(2), "english".into(), "cat dog".into());
+        session.input = vec!['c', 'a', 't', 'x', 'd', 'o'];
+        session.delete_word();
+        assert_eq!(session.input, vec!['c', 'a', 't', 'x']);
+    }
+
+    #[test]
+    fn delete_word_clears_single_word() {
+        let mut session = TestSession::new(TestMode::Words(1), "english".into(), "cat".into());
+        session.input = vec!['c', 'a'];
+        session.delete_word();
+        assert!(session.input.is_empty());
+    }
 
     #[test]
     fn computes_accuracy_from_input() {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -55,7 +55,10 @@ menu = ["tab m"]
 history = ["g"]
 cancel = ["esc"]
 backspace = ["backspace"]
+delete_word = ["ctrl+backspace", "ctrl+h", "ctrl+w", "alt+backspace"]
 ```
+
+`ctrl+backspace` is only delivered as such by terminals that support the kitty keyboard protocol (enabled automatically when available). Other terminals report it as `ctrl+h`, which the default bindings also cover.
 
 Supported modes:
 


### PR DESCRIPTION
## Summary

Adds a word-delete action to the typing test so you can clear a whole word at once instead of holding backspace — a small but meaningful UX improvement for fixing mistakes mid-test.

- New `delete_word` action on `TestSession` that deletes back to the previous word boundary, using the target text's spaces as boundaries (so a mistyped character at a space position still stops at the word edge).
- Bound to `ctrl+backspace`, `ctrl+w`, `ctrl+h`, and `alt+backspace`.
- The kitty keyboard protocol is negotiated at startup (`DISAMBIGUATE_ESCAPE_CODES`) so `ctrl+backspace` is delivered intact on terminals that support it; non-kitty terminals fall back to the other bindings.
- Char input now ignores keys carrying `CTRL`/`ALT` modifiers so the shortcuts don't get typed as literal characters.
- README and `docs/configuration.md` updated to document the new `delete_word` binding.

## Testing

- `cargo test -p tttui` — all tests pass, including new `delete_word` unit tests (empty input, partial word, word-start, mistyped-space boundary, single word).
- Manually verified the feature across multiple terminals:
  - **Kitty** and **Ghostty** — exercise the kitty keyboard protocol path (`ctrl+backspace` delivered with its modifier intact).
  - **GNOME Terminal (default)** — exercises the non-kitty keyboard protocol fallback path.

  Word deletion worked correctly in all three.

## Demo
https://github.com/user-attachments/assets/1a23b61b-d8fd-44da-83c4-582b2828e97c
